### PR TITLE
Hydrate model

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ $query_settings = [
     'sortables' => [
         'name' => 'asc',
     ],
+    
+    // optional, you can pass a model reference and the records returned 
+    // will be of that type
+    
+    'model' => User:class,
 ];
 
 $listing = $lister->make($query_settings)->get();

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -105,7 +105,16 @@ class Lister
      */
     private function fetchRecords()
     {
-        return $this->db->select($this->buildQuery());
+        $results = $this->db->select($this->buildQuery());
+
+        $model = ! empty($this->query_settings['model']) ? $this->query_settings['model'] : null;
+
+        if ($model && class_exists($model))
+        {
+            return $model::hydrate($results);
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/ListerTest.php
+++ b/tests/ListerTest.php
@@ -265,6 +265,32 @@ class ListerTest extends TestCase
         $this->assertTrue($listing->getResults()->count() > 1);
     }
 
+    public function testRecordsAreHydratedIfModelSet()
+    {
+        $query_settings = [
+            'fields' => "users.*",
+
+            'body' => "FROM users {filters}",
+
+            'filters' => [
+            ],
+
+            'sortables' => [
+                'name' => 'asc',
+            ],
+
+            'model' => User::class,
+        ];
+
+        $lister = new Lister($this->app->make(Request::class), $this->app->make(Connection::class));
+        $listing = $lister->make($query_settings)->get();
+
+        foreach($listing->results as $result)
+        {
+            $this->assertInstanceOf(User::class, $result);
+        }
+    }
+
     /**
      * Drop tables
      */


### PR DESCRIPTION
Added the ability to pass a model reference to query settings and the records fetched to be of that type.

```php
 $query_settings = [
    'fields' => "users.*",

    'body' => "FROM users {filters}",
    
     //

    'model` => App\Models\User::class,
   
];
```

Records fetched will be instances of `App\Models\User`
